### PR TITLE
Use Sub List in real world VRP test

### DIFF
--- a/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/vrp/VehicleRoutingBenchmark.java
+++ b/optaplanner-benchmarks/optaplanner-perf-benchmark/src/main/java/org/jboss/qa/brms/performance/realworld/vrp/VehicleRoutingBenchmark.java
@@ -12,13 +12,12 @@ import org.openjdk.jmh.annotations.Param;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
-import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicType;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.SwapMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainChangeMoveSelectorConfig;
-import org.optaplanner.core.config.heuristic.selector.move.generic.chained.SubChainSwapMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListChangeMoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.generic.list.SubListSwapMoveSelectorConfig;
 import org.optaplanner.core.config.localsearch.LocalSearchPhaseConfig;
 import org.optaplanner.core.config.localsearch.decider.acceptor.LocalSearchAcceptorConfig;
 import org.optaplanner.core.config.localsearch.decider.forager.LocalSearchForagerConfig;
@@ -71,20 +70,19 @@ public class VehicleRoutingBenchmark extends AbstractPlannerBenchmark<VehicleRou
 
     private List<PhaseConfig> getPhaseConfigList() {
         ConstructionHeuristicPhaseConfig constructionHeuristicPhaseConfig = new ConstructionHeuristicPhaseConfig();
-        constructionHeuristicPhaseConfig.setConstructionHeuristicType(ConstructionHeuristicType.FIRST_FIT_DECREASING);
 
         LocalSearchPhaseConfig localSearchPhaseConfig = new LocalSearchPhaseConfig();
 
-        SubChainChangeMoveSelectorConfig subChainChangeMoveSelectorConfig = new SubChainChangeMoveSelectorConfig();
-        subChainChangeMoveSelectorConfig.setSelectReversingMoveToo(true);
+        SubListChangeMoveSelectorConfig subListChangeMoveSelectorConfig = new SubListChangeMoveSelectorConfig();
+        subListChangeMoveSelectorConfig.setSelectReversingMoveToo(true);
 
-        SubChainSwapMoveSelectorConfig subChainSwapMoveSelectorConfig = new SubChainSwapMoveSelectorConfig();
-        subChainSwapMoveSelectorConfig.setSelectReversingMoveToo(true);
+        SubListSwapMoveSelectorConfig subListSwapMoveSelectorConfig = new SubListSwapMoveSelectorConfig();
+        subListSwapMoveSelectorConfig.setSelectReversingMoveToo(true);
 
         List<MoveSelectorConfig> moveSelectorConfigList = Arrays.asList(new ChangeMoveSelectorConfig(),
                                                                         new SwapMoveSelectorConfig(),
-                                                                        subChainChangeMoveSelectorConfig,
-                                                                        subChainSwapMoveSelectorConfig);
+                                                                        subListChangeMoveSelectorConfig,
+                                                                        subListSwapMoveSelectorConfig);
         UnionMoveSelectorConfig selectorConfig = new UnionMoveSelectorConfig(moveSelectorConfigList);
 
         LocalSearchForagerConfig foragerConfig = new LocalSearchForagerConfig();
@@ -94,6 +92,6 @@ public class VehicleRoutingBenchmark extends AbstractPlannerBenchmark<VehicleRou
         localSearchPhaseConfig.setMoveSelectorConfig(selectorConfig);
         localSearchPhaseConfig.setAcceptorConfig(new LocalSearchAcceptorConfig().withLateAcceptanceSize(ACCEPTOR_CONFIG_LATE_ACCEPTANCE_SIZE));
 
-        return Arrays.asList(constructionHeuristicPhaseConfig, localSearchPhaseConfig);
+        return Arrays.asList(constructionHeuristicPhaseConfig,localSearchPhaseConfig);
     }
 }


### PR DESCRIPTION
I checked all the examples at runtime and it occurs to me that the problem was only with realworld.vrp.VehicleRoutingBenchmark 
I adapted phase config to sub list instead of sub chain